### PR TITLE
Fixed 2 bugs in the ">>" button in the \Cars\All view.

### DIFF
--- a/CarRentingSystem/Views/Cars/All.cshtml
+++ b/CarRentingSystem/Views/Cars/All.cshtml
@@ -58,8 +58,14 @@
            asp-route-searchTerm="@Model.SearchTerm"
            asp-route-sorting="@((int)Model.Sorting)"><<</a>
     </div>
+    
+    @{
+        var shouldButtonBeDisabled = Model.CurrentPage == maxPage ||
+                                     !Model.Cars.Any();
+    }
+
     <div class="col-md-6">
-        <a class="btn btn-primary float-right @(Model.CurrentPage == maxPage ? "disabled" : string.Empty)"
+        <a class="btn btn-primary float-sm-right @(shouldButtonBeDisabled ? "disabled" : string.Empty)" style="margin-top: 10px"
            asp-controller="Cars"
            asp-action="All"
            asp-route-currentPage="@(Model.CurrentPage + 1)"


### PR DESCRIPTION
1.  When using the smartphone display mode from the browser's developer tools, the ">>" button shifted down a little bit. Now the button will either be under the "<<" button or it will be on the right side depending on the screen size.

2. When the Mode.Cars collection is empty the ">>"button was still clickable.  Now it will be disabled under this condition.